### PR TITLE
Fixed $username not working

### DIFF
--- a/src/v1/VoiceEvents/main.jsx
+++ b/src/v1/VoiceEvents/main.jsx
@@ -310,8 +310,8 @@ class Plugin {
 
         // speak message
         const msg = this.settings[type]
-            .split("$user").join(this.processName(nick))
             .split("$username").join(this.processName(user.username))
+            .split("$user").join(this.processName(nick))
             .split("$channel").join(this.processName(channelName));
         this.speak(msg);
     }


### PR DESCRIPTION
It split out $user before $username so all that was left was name so it didn't work. By reordering .split("$username") and .split("$user") it fixes this issue.