### PR TITLE
Added fallback functionality to the onChange event

### DIFF
--- a/src/BetterVolume/index.tsx
+++ b/src/BetterVolume/index.tsx
@@ -25,7 +25,10 @@ const NumberInput = ({value, min, max, fallback, onChange}: NumberInputProps): J
             min={min}
             max={max}
             value={Math.round((value + Number.EPSILON) * 100) / 100}
-            onChange={({target}) => onChange(limit(parseFloat(target.value), min, max))}
+            onChange={({target}) => {
+                const value = limit(parseFloat(target.value), min, max);
+                onChange(Number.isNaN(value) ? fallback : value);
+            }}
             onBlur={({target}) => {
                 const value = limit(parseFloat(target.value), min, max);
                 if (Number.isNaN(value)) {


### PR DESCRIPTION
Whenever a user manually removed the value in the input, it would set the volume to the maximum value allowed.

I don't like that my change now sets the value to 100% once they delete everything, it feels a bit rough visually when it happens.