### PR TITLE
Fix BetterFolders startup on recent Discord builds

### DIFF
--- a/dist/bd/BetterFolders.plugin.js
+++ b/dist/bd/BetterFolders.plugin.js
@@ -591,7 +591,6 @@ const index = createPlugin({
     start() {
         stopped = false;
         let FolderIcon = null;
-        const guildsOwner = getGuildsOwner();
         waitForWithKey(bySource$1("folderNode:", "folderGroupId:", "folderName"))
             .then((FolderIconWrapper) => {
             if (stopped) {
@@ -608,9 +607,13 @@ const index = createPlugin({
                 }
                 replaceElement(icon, React.createElement(ConnectedBetterFolderIcon, { folderId: props.folderNode.id, childProps: icon.props, FolderIcon: FolderIcon }));
             }, { name: "FolderIconWrapper" });
-            triggerRerender(guildsOwner);
+            triggerRerender(getGuildsOwner());
         })
-            .catch((error$1) => error("Failed to wait for FolderIconWrapper", error$1));
+            .catch((error$1) => {
+            if (!stopped && error$1?.name !== "AbortError") {
+                error("Failed to wait for FolderIconWrapper", error$1);
+            }
+        });
         after(ClientActions, "toggleGuildFolderExpand", ({ original, args: [folderId] }) => {
             if (Settings.current.closeOnOpen) {
                 for (const id of ExpandedGuildFolderStore.getExpandedFolders()) {
@@ -631,6 +634,10 @@ const index = createPlugin({
                 name: "FolderSettings mount",
                 force: true,
             });
+        }).catch((error$1) => {
+            if (!stopped && error$1?.name !== "AbortError") {
+                error("Failed to wait for FolderSettings", error$1);
+            }
         });
     },
     stop() {

--- a/dist/bd/BetterFolders.plugin.js
+++ b/dist/bd/BetterFolders.plugin.js
@@ -142,7 +142,6 @@ const resolveKey = (target, filter) => [
     target,
     (target ? Object.entries(target).find(([, value]) => filter(value))?.[0] : null),
 ];
-const findWithKey = (filter) => resolveKey(find(byEntry(filter)), filter);
 const demangle = (mapping, required, proxy = false) => {
     const req = Object.keys(mapping);
     const found = find((target) => checkObjectValues(target)
@@ -163,6 +162,10 @@ const waitFor = (filter, { resolve = true, entries = false } = {}) => BdApi.Webp
     defaultExport: resolve,
     searchExports: entries,
 });
+const waitForWithKey = async (filter) => {
+    const target = await waitFor(byEntry(filter));
+    return resolveKey(target, filter);
+};
 const abort = () => {
     controller.abort();
     controller = new AbortController();
@@ -583,23 +586,31 @@ const triggerRerender = async (guildsFiber) => {
         warn("Unable to rerender guilds");
     }
 };
+let stopped = false;
 const index = createPlugin({
     start() {
+        stopped = false;
         let FolderIcon = null;
         const guildsOwner = getGuildsOwner();
-        const FolderIconWrapper = findWithKey(bySource$1("folderNode:", "folderGroupId:", "folderName"));
-        after(...FolderIconWrapper, ({ args: [props], result }) => {
-            const icon = queryTree(result, (node) => node?.props?.folderNode);
-            if (!icon) {
-                return error("Unable to find FolderIcon component");
+        waitForWithKey(bySource$1("folderNode:", "folderGroupId:", "folderName"))
+            .then((FolderIconWrapper) => {
+            if (stopped) {
+                return;
             }
-            if (!FolderIcon) {
-                log("Found FolderIcon component");
-                FolderIcon = icon.type;
-            }
-            replaceElement(icon, React.createElement(ConnectedBetterFolderIcon, { folderId: props.folderNode.id, childProps: icon.props, FolderIcon: FolderIcon }));
-        }, { name: "FolderIconWrapper" });
-        triggerRerender(guildsOwner);
+            after(...FolderIconWrapper, ({ args: [props], result }) => {
+                const icon = queryTree(result, (node) => node?.props?.folderNode);
+                if (!icon) {
+                    return error("Unable to find FolderIcon component");
+                }
+                if (!FolderIcon) {
+                    log("Found FolderIcon component");
+                    FolderIcon = icon.type;
+                }
+                replaceElement(icon, React.createElement(ConnectedBetterFolderIcon, { folderId: props.folderNode.id, childProps: icon.props, FolderIcon: FolderIcon }));
+            }, { name: "FolderIconWrapper" });
+            triggerRerender(guildsOwner);
+        })
+            .catch((error$1) => error("Failed to wait for FolderIconWrapper", error$1));
         after(ClientActions, "toggleGuildFolderExpand", ({ original, args: [folderId] }) => {
             if (Settings.current.closeOnOpen) {
                 for (const id of ExpandedGuildFolderStore.getExpandedFolders()) {
@@ -610,6 +621,9 @@ const index = createPlugin({
             }
         });
         waitFor(bySource$1(".folderName", ".onClose"), { entries: true }).then((FolderSettings) => {
+            if (stopped) {
+                return;
+            }
             after(FolderSettings.prototype, "render", renderFolderSettingsPatch, {
                 name: "FolderSettings render",
             });
@@ -620,6 +634,7 @@ const index = createPlugin({
         });
     },
     stop() {
+        stopped = true;
         triggerRerender(getGuildsOwner());
     },
     styles: css,

--- a/src/BetterFolders/index.tsx
+++ b/src/BetterFolders/index.tsx
@@ -30,46 +30,56 @@ const triggerRerender = async (guildsFiber: Fiber) => {
     }
 };
 
+let stopped = false;
+
 export default createPlugin({
     start() {
+        stopped = false;
         let FolderIcon: FolderIcon = null;
         const guildsOwner = getGuildsOwner();
 
         // patch folder icon wrapper
         // icon is in same module, not exported
-        const FolderIconWrapper = Finder.findWithKey<React.FunctionComponent<PropsWithFolderNode>>(
+        Finder.waitForWithKey<React.FunctionComponent<PropsWithFolderNode>>(
             Filters.bySource("folderNode:", "folderGroupId:", "folderName"),
-        );
-        Patcher.after(
-            ...FolderIconWrapper,
-            ({ args: [props], result }) => {
-                const icon = Utils.queryTree(result, (node) => node?.props?.folderNode) as React.ReactElement<
-                    PropsWithFolderNode,
-                    FolderIcon
-                >;
-                if (!icon) {
-                    return Logger.error("Unable to find FolderIcon component");
+        )
+            .then((FolderIconWrapper) => {
+                if (stopped) {
+                    return;
                 }
 
-                // save icon component
-                if (!FolderIcon) {
-                    Logger.log("Found FolderIcon component");
-                    FolderIcon = icon.type;
-                }
+                Patcher.after(
+                    ...FolderIconWrapper,
+                    ({ args: [props], result }) => {
+                        const icon = Utils.queryTree(result, (node) => node?.props?.folderNode) as React.ReactElement<
+                            PropsWithFolderNode,
+                            FolderIcon
+                        >;
+                        if (!icon) {
+                            return Logger.error("Unable to find FolderIcon component");
+                        }
 
-                // replace icon with own component
-                Utils.replaceElement(
-                    icon,
-                    <ConnectedBetterFolderIcon
-                        folderId={props.folderNode.id}
-                        childProps={icon.props}
-                        FolderIcon={FolderIcon}
-                    />,
+                        // save icon component
+                        if (!FolderIcon) {
+                            Logger.log("Found FolderIcon component");
+                            FolderIcon = icon.type;
+                        }
+
+                        // replace icon with own component
+                        Utils.replaceElement(
+                            icon,
+                            <ConnectedBetterFolderIcon
+                                folderId={props.folderNode.id}
+                                childProps={icon.props}
+                                FolderIcon={FolderIcon}
+                            />,
+                        );
+                    },
+                    { name: "FolderIconWrapper" },
                 );
-            },
-            { name: "FolderIconWrapper" },
-        );
-        triggerRerender(guildsOwner);
+                triggerRerender(guildsOwner);
+            })
+            .catch((error) => Logger.error("Failed to wait for FolderIconWrapper", error));
 
         // patch folder expand
         Patcher.after(ClientActions, "toggleGuildFolderExpand", ({ original, args: [folderId] }) => {
@@ -85,6 +95,10 @@ export default createPlugin({
         // patch folder settings class
         Finder.waitFor<FolderSettingsClass>(Filters.bySource(".folderName", ".onClose"), { entries: true }).then(
             (FolderSettings) => {
+                if (stopped) {
+                    return;
+                }
+
                 Patcher.after(FolderSettings.prototype, "render", renderFolderSettingsPatch, {
                     name: "FolderSettings render",
                 });
@@ -96,6 +110,7 @@ export default createPlugin({
         );
     },
     stop() {
+        stopped = true;
         triggerRerender(getGuildsOwner());
     },
     styles: css,

--- a/src/BetterFolders/index.tsx
+++ b/src/BetterFolders/index.tsx
@@ -36,7 +36,6 @@ export default createPlugin({
     start() {
         stopped = false;
         let FolderIcon: FolderIcon = null;
-        const guildsOwner = getGuildsOwner();
 
         // patch folder icon wrapper
         // icon is in same module, not exported
@@ -77,9 +76,13 @@ export default createPlugin({
                     },
                     { name: "FolderIconWrapper" },
                 );
-                triggerRerender(guildsOwner);
+                triggerRerender(getGuildsOwner());
             })
-            .catch((error) => Logger.error("Failed to wait for FolderIconWrapper", error));
+            .catch((error) => {
+                if (!stopped && error?.name !== "AbortError") {
+                    Logger.error("Failed to wait for FolderIconWrapper", error);
+                }
+            });
 
         // patch folder expand
         Patcher.after(ClientActions, "toggleGuildFolderExpand", ({ original, args: [folderId] }) => {
@@ -107,7 +110,11 @@ export default createPlugin({
                     force: true,
                 });
             },
-        );
+        ).catch((error) => {
+            if (!stopped && error?.name !== "AbortError") {
+                Logger.error("Failed to wait for FolderSettings", error);
+            }
+        });
     },
     stop() {
         stopped = true;


### PR DESCRIPTION
## Summary
- switch BetterFolders folder icon patching from synchronous lookup to lazy module waiting
- guard lazy patch callbacks against plugin stop races and ignore expected AbortError shutdowns
- rerender guilds using a fresh owner lookup after lazy patch application

## Testing
- npm run check
- npm run lint -- src/BetterFolders/index.tsx
- npm run build -- BetterFolders

Closes #236